### PR TITLE
Fix compile on ESP-IDF 5.0

### DIFF
--- a/src/veml7700.c
+++ b/src/veml7700.c
@@ -535,7 +535,7 @@ esp_err_t veml7700_read_als_lux_auto(veml7700_handle_t dev, double* lux)
 {
 	veml7700_read_als_lux(dev, lux);
 
-	ESP_LOGD(VEML7700_TAG, "Configured maximum luminocity: %d\n", dev->configuration.maximum_lux);
+	ESP_LOGD(VEML7700_TAG, "Configured maximum luminocity: %ld\n", dev->configuration.maximum_lux);
 	ESP_LOGD(VEML7700_TAG, "Configured resolution: %0.4f\n", dev->configuration.resolution);
 	
 	// Calculate and automatically reconfigure the optimal sensor configuration
@@ -568,7 +568,7 @@ esp_err_t veml7700_read_white_lux_auto(veml7700_handle_t dev, double* lux)
 {
 	veml7700_read_white_lux(dev, lux);
 
-	ESP_LOGD(VEML7700_TAG, "Configured maximum luminocity: %d\n", dev->configuration.maximum_lux);
+	ESP_LOGD(VEML7700_TAG, "Configured maximum luminocity: %ld\n", dev->configuration.maximum_lux);
 	ESP_LOGD(VEML7700_TAG, "Configured resolution: %0.4f\n", dev->configuration.resolution);
 	
 	// Calculate and automatically reconfigure the optimal sensor configuration

--- a/src/veml7700.c
+++ b/src/veml7700.c
@@ -535,7 +535,7 @@ esp_err_t veml7700_read_als_lux_auto(veml7700_handle_t dev, double* lux)
 {
 	veml7700_read_als_lux(dev, lux);
 
-	ESP_LOGD(VEML7700_TAG, "Configured maximum luminocity: %ld\n", dev->configuration.maximum_lux);
+	ESP_LOGD(VEML7700_TAG, "Configured maximum luminocity: %" PRIu32 "\n", dev->configuration.maximum_lux);
 	ESP_LOGD(VEML7700_TAG, "Configured resolution: %0.4f\n", dev->configuration.resolution);
 	
 	// Calculate and automatically reconfigure the optimal sensor configuration
@@ -568,7 +568,7 @@ esp_err_t veml7700_read_white_lux_auto(veml7700_handle_t dev, double* lux)
 {
 	veml7700_read_white_lux(dev, lux);
 
-	ESP_LOGD(VEML7700_TAG, "Configured maximum luminocity: %ld\n", dev->configuration.maximum_lux);
+	ESP_LOGD(VEML7700_TAG, "Configured maximum luminocity: %" PRIu32 "\n", dev->configuration.maximum_lux);
 	ESP_LOGD(VEML7700_TAG, "Configured resolution: %0.4f\n", dev->configuration.resolution);
 	
 	// Calculate and automatically reconfigure the optimal sensor configuration


### PR DESCRIPTION
ESP-IDF now uses `long` for the `uint32_t` type; format specifiers need to support the type change. `"%" PRIu32` is now used in place of `"%d"`, which should support both the ESP-IDF 5.0-rc1 prerelease as well as the 4.x stable releases.
See https://docs.espressif.com/projects/esp-idf/en/v5.0-rc1/esp32/migration-guides/release-5.x/gcc.html#int32-t-and-uint32-t-for-xtensa-compiler.